### PR TITLE
fix lsb and os-release probes

### DIFF
--- a/os-prober-fix-lsb-and-os-release.patch
+++ b/os-prober-fix-lsb-and-os-release.patch
@@ -1,0 +1,102 @@
+diff --git a/os-probes/mounted/common/35os-release b/os-probes/mounted/common/35os-release
+new file mode 100755
+index 0000000..9e3b5d3
+--- /dev/null
++++ b/os-probes/mounted/common/35os-release
+@@ -0,0 +1,44 @@
++#!/bin/sh
++# Test for Linux distributions
++set -e
++
++. /usr/share/os-prober/common.sh
++
++partition="$1"
++dir="$2"
++type="$3"
++
++os_field () {
++	file="$1"
++	field="$2"
++	grep ^"$field=" "$file" | cut -d = -f 2 | sed 's/^"//' | sed 's/"$//' | sed 's/:/ /g'
++}
++
++file="$dir/etc/os-release"
++if [ ! -e "$file" ]; then
++	exit 1
++fi
++
++long=$(os_field "$file" PRETTY_NAME)
++if [ -z "$long" ]; then
++	name=$(os_field "$file" NAME)
++	if [ -z "$name" ]; then
++		exit 1
++	fi
++
++	version=$(os_field "$file" VERSION)
++	if [ -n "$version" ]; then
++		long="$name $version"
++	else
++		long="$name"
++	fi
++fi
++
++short=$(os_field "$file" ID | sed 's/ //g')
++if [ -z "$short" ]; then
++	short="linux"
++fi
++
++label="$(count_next_label "$short")"
++result "$partition:$long:$label:linux"
++exit 0
+diff --git a/os-probes/mounted/common/40lsb b/os-probes/mounted/common/40lsb
+index ce8d4e1..52b5046 100755
+--- a/os-probes/mounted/common/40lsb
++++ b/os-probes/mounted/common/40lsb
+@@ -11,7 +11,7 @@ type="$3"
+ lsb_field () {
+ 	file="$1"
+ 	field="$2"
+-	grep ^"$field" "$file" | cut -d = -f 2 | sed 's/^"//' | sed 's/"$//' | sed 's/:/ /g'
++	grep ^"$field=" "$file" | cut -d = -f 2 | sed 's/^"//' | sed 's/"$//' | sed 's/:/ /g'
+ }
+ 
+ file="$dir/etc/lsb-release"
+@@ -19,23 +19,24 @@ if [ ! -e "$file" ]; then
+ 	exit 1
+ fi
+ 
+-release=$(lsb_field "$file" DISTRIB_RELEASE)
+-if [ -z "$release" ]; then
+-	release=$(lsb_field "$file" DISTRIB_CODENAME)
+-fi
+-description=$(lsb_field "$file" DISTRIB_DESCRIPTION)
+-if [ -z "$description" ]; then
+-	description=$(lsb_field "$file" DISTRIB_CODENAME)
+-fi
++long=$(lsb_field "$file" DISTRIB_DESCRIPTION)
++if [ -z "$long" ]; then
++	name=$(lsb_field "$file" DISTRIB_ID)
++	if [ -z "$name" ]; then
++		exit 1
++	fi
+ 
+-if [ -n "$description" ]; then
+-	if [ -n "$release" ]; then
+-		long="$description ($release)"
++	version=$(lsb_field "$file" DISTRIB_RELEASE)
++	if [ -n "$version" ]; then
++		long="$name $version"
+ 	else
+-		long="$description"
++		long="$name"
+ 	fi
+-else
+-	exit 1
++fi
++
++codename=$(lsb_field "$file" DISTRIB_CODENAME)
++if [ -n "$codename" ]; then
++	long="$long ($codename)"
+ fi
+ 
+ short=$(lsb_field "$file" DISTRIB_ID | sed 's/ //g')

--- a/os-prober.spec
+++ b/os-prober.spec
@@ -38,6 +38,8 @@ Patch21:	os-prober-linux-distro-avoid-expensive-ld-file-test.patch
 Patch22:	os-prober-linux-distro-parse-os-release.patch
 #Fixes OMA bug 2234
 Patch23:	microcode-initrd-line-fix.patch
+№ Fixes lsb and os-release probes
+Patch24:	os-prober-fix-lsb-and-os-release.patch
 Requires:	coreutils
 Requires:	grep
 Requires:	sed


### PR DESCRIPTION
Hi. I have already tried to send these changes to the upstream project.

https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=913733 Date: Wed, 14 Nov 2018 12:57:02 UTC

https://www.freedesktop.org/software/systemd/man/os-release.html Every Linux distribution has this file totally ignored by os-prober

Before /dev/sda1:Debian GNU/Linux 9 (9):debian:linux
After /dev/sda1:Debian GNU/Linux 9 (stretch):debian:linux